### PR TITLE
[FEATURE] added title attribute to resource in acl.xml

### DIFF
--- a/etc/acl.xml
+++ b/etc/acl.xml
@@ -5,7 +5,7 @@
         <resources>
             <resource id="Magento_Backend::admin">
                 <resource id="Magento_Backend::content">
-                    <resource id="DR_Gallery::gallery">
+                    <resource id="DR_Gallery::gallery" title="Gallery">
                         <resource id="DR_Gallery::gallery_gallery"
                                   title="Gallery"
                                   sortOrder="95">


### PR DESCRIPTION
fixes an issue where a missing title attribute prevents the acl tree from fully rendering, thus keeping the role tree from being displayed.